### PR TITLE
Prevent a complete recompile when no source has changed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/launch.json
 .vscode/ipch
 include/WiFiCredentials.h
+include/build_epoch.h

--- a/generate_build_epoch.py
+++ b/generate_build_epoch.py
@@ -12,7 +12,7 @@ human_readable_time = datetime.fromtimestamp(build_epoch, tz=timezone.utc).strft
 with open(header_file, "w") as f:
     f.write(f"#ifndef BUILD_EPOCH_H\n")
     f.write(f"#define BUILD_EPOCH_H\n\n")
-    f.write(f"#define BUILD_EPOCH {build_epoch} // {human_readable_time}\n\n")
+    f.write(f"#define BUILD_EPOCH {build_epoch} // {human_readable_time} UTC\n\n")
     f.write(f"#endif // BUILD_EPOCH_H\n")
 
 print(f"Generated {header_file} with BUILD_EPOCH={build_epoch} ({human_readable_time})")

--- a/generate_build_epoch.py
+++ b/generate_build_epoch.py
@@ -1,18 +1,28 @@
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta
+import time
 
 # File to generate
 header_file = os.path.join("include", "build_epoch.h")
 
-# Generate UNIX timestamp and human-readable timestamp
-build_epoch = int(datetime.now(timezone.utc).timestamp())
-human_readable_time = datetime.fromtimestamp(build_epoch, tz=timezone.utc).strftime("%A %d %B %Y %H:%M")
+# Get the system's local timezone offset
+local_offset = time.localtime().tm_gmtoff
+# Get the sign of the offset and format it
+sign = "+" if local_offset >= 0 else "-"
+abs_offset = abs(local_offset)
+offset_hours = abs_offset // 3600
+offset_minutes = (abs_offset % 3600) // 60
+
+# Generate UNIX timestamp and human-readable timestamp in the local timezone
+build_epoch = int(datetime.now().timestamp())
+local_time = datetime.fromtimestamp(build_epoch) + timedelta(seconds=local_offset)
+human_readable_time = local_time.strftime(f"%A %d %B %Y %H:%M UTC{sign}{offset_hours:02}:{offset_minutes:02}")
 
 # Create or overwrite the header file
 with open(header_file, "w") as f:
-    f.write(f"#ifndef BUILD_EPOCH_H\n")
-    f.write(f"#define BUILD_EPOCH_H\n\n")
-    f.write(f"#define BUILD_EPOCH {build_epoch} // {human_readable_time} UTC\n\n")
-    f.write(f"#endif // BUILD_EPOCH_H\n")
+    f.write("#ifndef BUILD_EPOCH_H\n")
+    f.write("#define BUILD_EPOCH_H\n\n")
+    f.write(f"#define BUILD_EPOCH {build_epoch} // {human_readable_time}\n\n")
+    f.write("#endif // BUILD_EPOCH_H\n")
 
 print(f"Generated {header_file} with BUILD_EPOCH={build_epoch} ({human_readable_time})")

--- a/generate_build_epoch.py
+++ b/generate_build_epoch.py
@@ -1,0 +1,18 @@
+import os
+from datetime import datetime, timezone
+
+# File to generate
+header_file = os.path.join("include", "build_epoch.h")
+
+# Generate UNIX timestamp and human-readable timestamp
+build_epoch = int(datetime.now(timezone.utc).timestamp())
+human_readable_time = datetime.fromtimestamp(build_epoch, tz=timezone.utc).strftime("%A %d %B %Y %H:%M")
+
+# Create or overwrite the header file
+with open(header_file, "w") as f:
+    f.write(f"#ifndef BUILD_EPOCH_H\n")
+    f.write(f"#define BUILD_EPOCH_H\n\n")
+    f.write(f"#define BUILD_EPOCH {build_epoch} // {human_readable_time}\n\n")
+    f.write(f"#endif // BUILD_EPOCH_H\n")
+
+print(f"Generated {header_file} with BUILD_EPOCH={build_epoch} ({human_readable_time})")

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,9 @@ build_flags =
     -D NTP_POOL=\"nl.pool.ntp.org\"
     -D TIMEZONE=\"CET-1CEST,M3.5.0/2,M10.5.0/3\" ; /* Central European Time - see https://sites.google.com/a/usapiens.com/opnode/time-zones
 
+[env]
+extra_scripts = pre:generate_build_epoch.py
+
 [env:adafruit_feather_esp32s3_reversetft]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 board = adafruit_feather_esp32s3_reversetft
@@ -40,7 +43,6 @@ lib_ldf_mode = chain+
 build_unflags = -std=c++11
 build_flags =
     ${user.build_flags}
-    -D BUILD_EPOCH=$UNIX_TIME
     -D ARDUINO_USB_MODE=1 ; fix for not resetting after upload
     -D BOARD_HAS_PSRAM
     -std=c++17

--- a/src/servertask.cpp
+++ b/src/servertask.cpp
@@ -1,4 +1,5 @@
 #include "servertask.h"
+#include "build_epoch.h"
 
 static const char *HEADER_MODIFIED_SINCE = "If-Modified-Since";
 


### PR DESCRIPTION
This PR solves the issue that the program is completely recompiled every time even if no source has changed.

Cause is the `-D BUILD_EPOCH=$UNIX_TIME` line in `platformio.ini`.

Solution:
Use a header file in the include folder for generated `BUILD_EPOCH` to not trigger a complete recompilation every time the program is compiled.